### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=cybersyn-combinator] Move to circuit-combinator subgroup if SchallCircuitGroup is installed.

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-final-fixes.schall-circuit-group")

--- a/data-final-fixes/schall-circuit-group.lua
+++ b/data-final-fixes/schall-circuit-group.lua
@@ -1,0 +1,4 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["cybersyn-combinator"].subgroup = "circuit-combinator"
+  data.raw.recipe["cybersyn-combinator"].subgroup = "circuit-combinator"
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
-    "cybersyn >= 2.0.0"
+    "cybersyn >= 2.0.0",
+    "? SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=cybersyn-combinator] Move to circuit-combinator subgroup if SchallCircuitGroup is installed.